### PR TITLE
Stop using reserved JavaScript keyword `package`

### DIFF
--- a/lib/atom-go-jump-test.js
+++ b/lib/atom-go-jump-test.js
@@ -56,13 +56,13 @@ func TestName(t *testing.T) {
       otherFile = path.join(cwd, otherFile)
     }
     if(!fs.existsSync(otherFile)) {
-      package = this.determinePackage(editor.getText())
+      let pack = this.determinePackage(editor.getText())
       if(otherFile.includes("_test.go")) {
         template = this.TEMPLATE_TEST;
       } else {
         template = this.TEMPLATE_IMPL;
       }
-      content = template.replace("##package##", package)
+      content = template.replace("##package##", pack)
       fs.writeFileSync(otherFile, content)
     }
     return openFile(otherFile)


### PR DESCRIPTION
In the process of upgrading babel in Atom core (https://github.com/atom/atom/pull/13823) we have noticed this package uses JavaScript features that are either deprecated or that are incompatible with the language specification.

This pull request changes the code to stop using such features so that the package keeps working when the babel upgrade will be merged and released.

I have enabled edits from maintainers, so feel free to make any changes to this branch! Also, please let me know if you have any questions or concerns and if I can help somehow. Thanks!